### PR TITLE
시크릿키 환경변수 case insensitive화

### DIFF
--- a/DjangoCRUDBoard/secret_key.py
+++ b/DjangoCRUDBoard/secret_key.py
@@ -1,3 +1,3 @@
 import os
 
-SECRET_KEY = os.environ['Django_secret_key']
+SECRET_KEY = os.environ['Django_secret_key'] if 'Django_secret_key' in os.environ else os.environ['Django_secret_key'.upper()]


### PR DESCRIPTION
### 동기
github secret이 대문자로만 적용되어 테스트에서 KeyError 발생

### 처리
일반 케이스 키값이 환경변수에 있으면 적용하고, 아니면 대문자로 된 키값을 사용하기로 삼항 연산자를 사용하여 구현하였음