### PR TITLE
Set django to 2.1.15

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ dj-database-url = "==0.5.0"
 psycopg2-binary = "==2.8.6"
 pytz = "==2020.5"
 sqlparse = "*"
-Django = "==3.1.4"
+Django = "==2.1.15"
 pyjwt = "==2.0.0"
 
 [dev-packages]


### PR DESCRIPTION
### 동기
Beanstalk와 장고 호환성 문제
### 관련 문서
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create-deploy-python-django.html