### PR TITLE
Fix: watchtower docker config.json volume path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /root/.docker/config.json:/config.json
+      - ~/.docker/config.json:/config.json
     command: --interval 30
   prometheus:
     container_name: prometheus


### PR DESCRIPTION
* mac에서는 /root 폴더가 없음
* 호환성이 좋은 사용자 경로 ~/.docker 폴더로 대체하도록 함