### PR TITLE
Remove certbot 12h renewal command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,12 +109,12 @@ services:
     environment:
     - NGINX_HOST=0.0.0.0
     - NGINX_PORT=80
-  certbot:
-    image: certbot/certbot
-    volumes:
-      - ./data/certbot/conf:/etc/letsencrypt
-      - ./data/certbot/www:/var/www/certbot
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+  # certbot:
+  #   image: certbot/certbot
+  #   volumes:
+  #     - ./data/certbot/conf:/etc/letsencrypt
+  #     - ./data/certbot/www:/var/www/certbot
+  #   entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
 
   cadvisor:
       image: google/cadvisor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,12 +109,11 @@ services:
     environment:
     - NGINX_HOST=0.0.0.0
     - NGINX_PORT=80
-  # certbot:
-  #   image: certbot/certbot
-  #   volumes:
-  #     - ./data/certbot/conf:/etc/letsencrypt
-  #     - ./data/certbot/www:/var/www/certbot
-  #   entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+  certbot:
+    image: certbot/certbot
+    volumes:
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
 
   cadvisor:
       image: google/cadvisor


### PR DESCRIPTION
https://medium.com/@pentacent/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71
이 튜토리얼로 진행하였으니 일주일에 5회 갱신 제한이 있어 certbot command를 계속 실행하는것은 부적합하다고 판단하였음
https://letsencrypt.org/docs/rate-limits/